### PR TITLE
Subaru Crosstrek Hybrid 2023 - Fingerprint

### DIFF
--- a/selfdrive/car/subaru/values.py
+++ b/selfdrive/car/subaru/values.py
@@ -325,6 +325,7 @@ FW_VERSIONS = {
     (Ecu.eps, 0x746, None): [
       b'\x9a\xc2\x01\x00',
       b'\n\xc2\x01\x00',
+      b'\n\xc2\x01\x01',
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00el\x1f@ #',
@@ -335,6 +336,7 @@ FW_VERSIONS = {
       b'\xd7!`p\a',
       b'\xe9\xf5B0\x00',
       b'\xf4!`0\x07',
+      b'\xf5!`0\x07',
     ],
   },
   CAR.FORESTER: {


### PR DESCRIPTION
**Checklist**
- [x] added entry to CarInfo in selfdrive/car/*/values.py 
- [ ] ran `selfdrive/car/docs.py` to generate new docs
```
❯ python docs.py
Traceback (most recent call last):
  File "/Users/nlorio/Documents/personal/openpilot/selfdrive/car/docs.py", line 4, in <module>
    import jinja2
ModuleNotFoundError: No module named 'jinja2'
```
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py) 
```
2023H is grouped with 2020H for fingerprinting, uncertain as to how tests are structured in this project

route: fd8fbb303d6fd9ec|2023-12-21--17-05-40
segment: 0
```
- [x] route with openpilot:
- [x] route with stock system:

**Concerns**

Tuning for Crosstrek Hybrid 2023 is required. Will address this in a separate PR. The current configuration with steerRatio set to 17 results in ping-ponging between lane identifiers. 